### PR TITLE
Fix misspelled function name in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Enjoy!
     ```
 * Create an executor backed by a single thread:
    ```go
-   ex := executor.NewSingleThreadPool("executorName", 200)
+   ex := executor.NewSingleThreadExecutor("executorName", 200)
    // 200 = Task Queue Size
    ```
 


### PR DESCRIPTION
NewSingleThreadPool function seems to be in fact named NewSingleThreadExecutor.